### PR TITLE
Client: add flush timeout 

### DIFF
--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -82,10 +82,8 @@ where
 
 /// Blocks on `nb` function calls but allow to time out
 /// Example of usage:
-/// ```
-/// block_timeout!((client.timer, client.config.tx_timeout) => {client.tx.write(c)}.map_err(|_e| Error::Write))?;
-/// block_timeout!((client.timer, client.config.tx_timeout) => {client.tx.write(c)});
-/// ```
+/// `block_timeout!((client.timer, client.config.tx_timeout) => {client.tx.write(c)}.map_err(|_e| Error::Write))?;`
+/// `block_timeout!((client.timer, client.config.tx_timeout) => {client.tx.write(c)});`
 #[macro_export]
 macro_rules! block_timeout {
     ($timer:expr, $duration:expr, $e:expr, $map_err:expr) => {{

--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -721,8 +721,8 @@ mod test {
 
     #[test]
     fn tx_timeout() {
-        let timeout = Duration::from_millis(10);
-        let (mut client, mut p, _) = setup!(Config::new(Mode::Blocking).tx_timeout(5), timeout);
+        let timeout = Duration::from_millis(20);
+        let (mut client, mut p, _) = setup!(Config::new(Mode::Blocking).tx_timeout(1), timeout);
 
         let cmd = SetModuleFunctionality {
             fun: Functionality::APM,
@@ -738,8 +738,8 @@ mod test {
 
     #[test]
     fn flush_timeout() {
-        let timeout = Duration::from_millis(10);
-        let (mut client, mut p, _) = setup!(Config::new(Mode::Blocking).flush_timeout(5), timeout);
+        let timeout = Duration::from_millis(20);
+        let (mut client, mut p, _) = setup!(Config::new(Mode::Blocking).flush_timeout(1), timeout);
 
         let cmd = SetModuleFunctionality {
             fun: Functionality::APM,

--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -108,7 +108,7 @@ macro_rules! block_timeout {
         }
     }};
     (($timer:expr, $duration:expr) => {$e:expr}) => {{
-        block_timeout!($timer, $duration, $e, |e|{e})
+        block_timeout!($timer, $duration, $e, |e| { e })
     }};
     (($timer:expr, $duration:expr) => {$e:expr}.map_err($map_err:expr)) => {{
         block_timeout!($timer, $duration, $e, $map_err)
@@ -333,7 +333,11 @@ mod test {
 
     impl TxMock {
         fn new(s: String<64>, timeout: Option<Duration>) -> Self {
-            TxMock { s, timeout, timer_start: None }
+            TxMock {
+                s,
+                timeout,
+                timer_start: None,
+            }
         }
     }
 

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -271,6 +271,8 @@ pub use traits::{AtatClient, AtatCmd, AtatResp, AtatUrc};
 pub struct Config {
     mode: Mode,
     cmd_cooldown: u32,
+    tx_timeout: u32,
+    flush_timeout: u32,
 }
 
 impl Default for Config {
@@ -278,6 +280,8 @@ impl Default for Config {
         Self {
             mode: Mode::Blocking,
             cmd_cooldown: 20,
+            tx_timeout: 0,
+            flush_timeout: 0,
         }
     }
 }
@@ -289,6 +293,18 @@ impl Config {
             mode,
             ..Self::default()
         }
+    }
+
+    #[must_use]
+    pub const fn tx_timeout(mut self, ms: u32) -> Self {
+        self.tx_timeout = ms;
+        self
+    }
+
+    #[must_use]
+    pub const fn flush_timeout(mut self, ms: u32) -> Self {
+        self.flush_timeout = ms;
+        self
     }
 
     #[must_use]


### PR DESCRIPTION
We are currently using a commit rev from this branch ([client: add tx timeout, cleanup](https://github.com/yaak-ai/atat/commit/dc0fdca7ab23ede18f08a00a43bb2aa2d6d0dd45)) on `esp32rogue`.
This PR will merge the branch into `master` so we can refer to something that is properly merged and that passes tests, and not on potentially orphaned commit in the future.
