### PR TITLE
Log unknown CME error code

### DIFF
--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -82,10 +82,8 @@ where
 
 /// Blocks on `nb` function calls but allow to time out
 /// Example of usage:
-/// ```
-/// block_timeout!((client.timer, client.config.tx_timeout) => {client.tx.write(c)}.map_err(|_e| Error::Write))?;
-/// block_timeout!((client.timer, client.config.tx_timeout) => {client.tx.write(c)});
-/// ```
+/// `block_timeout!((client.timer, client.config.tx_timeout) => {client.tx.write(c)}.map_err(|_e| Error::Write))?;`
+/// `block_timeout!((client.timer, client.config.tx_timeout) => {client.tx.write(c)});`
 #[macro_export]
 macro_rules! block_timeout {
     ($timer:expr, $duration:expr, $e:expr, $map_err:expr) => {{

--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -721,8 +721,8 @@ mod test {
 
     #[test]
     fn tx_timeout() {
-        let timeout = Duration::from_millis(10);
-        let (mut client, mut p, _) = setup!(Config::new(Mode::Blocking).tx_timeout(5), timeout);
+        let timeout = Duration::from_millis(20);
+        let (mut client, mut p, _) = setup!(Config::new(Mode::Blocking).tx_timeout(1), timeout);
 
         let cmd = SetModuleFunctionality {
             fun: Functionality::APM,
@@ -738,8 +738,8 @@ mod test {
 
     #[test]
     fn flush_timeout() {
-        let timeout = Duration::from_millis(10);
-        let (mut client, mut p, _) = setup!(Config::new(Mode::Blocking).flush_timeout(5), timeout);
+        let timeout = Duration::from_millis(20);
+        let (mut client, mut p, _) = setup!(Config::new(Mode::Blocking).flush_timeout(1), timeout);
 
         let cmd = SetModuleFunctionality {
             fun: Functionality::APM,

--- a/atat/src/client.rs
+++ b/atat/src/client.rs
@@ -108,7 +108,7 @@ macro_rules! block_timeout {
         }
     }};
     (($timer:expr, $duration:expr) => {$e:expr}) => {{
-        block_timeout!($timer, $duration, $e, |e|{e})
+        block_timeout!($timer, $duration, $e, |e| { e })
     }};
     (($timer:expr, $duration:expr) => {$e:expr}.map_err($map_err:expr)) => {{
         block_timeout!($timer, $duration, $e, $map_err)
@@ -333,7 +333,11 @@ mod test {
 
     impl TxMock {
         fn new(s: String<64>, timeout: Option<Duration>) -> Self {
-            TxMock { s, timeout, timer_start: None }
+            TxMock {
+                s,
+                timeout,
+                timer_start: None,
+            }
         }
     }
 

--- a/atat/src/digest.rs
+++ b/atat/src/digest.rs
@@ -202,10 +202,13 @@ pub mod parser {
         alt((
             // Matches the equivalent of regex: "\r\n\+CME ERROR:\s*(\d+)\r\n"
             map(numeric_error("\r\n+CME ERROR:"), |(error_code, len)| {
+                let cme_error = CmeError::from(error_code);
+                match cme_error {
+                    CmeError::Unknown if error_code != 100 => error!("Unknown CME error: {error_code}"),
+                    _ => ()
+                }
                 (
-                    DigestResult::Response(Err(InternalError::CmeError(CmeError::from(
-                        error_code,
-                    )))),
+                    DigestResult::Response(Err(InternalError::CmeError(cme_error))),
                     len,
                 )
             }),

--- a/atat/src/lib.rs
+++ b/atat/src/lib.rs
@@ -271,6 +271,8 @@ pub use traits::{AtatClient, AtatCmd, AtatResp, AtatUrc};
 pub struct Config {
     mode: Mode,
     cmd_cooldown: u32,
+    tx_timeout: u32,
+    flush_timeout: u32,
 }
 
 impl Default for Config {
@@ -278,6 +280,8 @@ impl Default for Config {
         Self {
             mode: Mode::Blocking,
             cmd_cooldown: 20,
+            tx_timeout: 0,
+            flush_timeout: 0,
         }
     }
 }
@@ -289,6 +293,18 @@ impl Config {
             mode,
             ..Self::default()
         }
+    }
+
+    #[must_use]
+    pub const fn tx_timeout(mut self, ms: u32) -> Self {
+        self.tx_timeout = ms;
+        self
+    }
+
+    #[must_use]
+    pub const fn flush_timeout(mut self, ms: u32) -> Self {
+        self.flush_timeout = ms;
+        self
     }
 
     #[must_use]


### PR DESCRIPTION
Currently when we receive an unknown error from the modem we don't really see any relevant info because every u-blox-specific error codes are mapped to unknown.
This PR print the error code so it can be matched in the [AT command manual](https://content.u-blox.com/sites/default/files/SARA-R5_ATCommands_UBX-19047455.pdf) (appending A1, p464)